### PR TITLE
feat: 🎸 basic auth and path aliases

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,9 +1,9 @@
 module.exports = {
-	"useTabs": true,
-	"singleQuote": true,
-	"trailingComma": "none",
-	"printWidth": 100,
-	"plugins": ["prettier-plugin-svelte"],
-	"pluginSearchDirs": ["."],
-	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
-}
+	useTabs: true,
+	singleQuote: true,
+	trailingComma: 'none',
+	printWidth: 100,
+	plugins: ['prettier-plugin-svelte'],
+	pluginSearchDirs: ['.'],
+	overrides: [{ files: '*.svelte', options: { parser: 'svelte' } }]
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
 			"name": "project-d",
 			"version": "0.0.1",
 			"dependencies": {
+				"@auth/core": "^0.5.0",
+				"@auth/sveltekit": "^0.2.2",
 				"zod": "^3.20.6"
 			},
 			"devDependencies": {
@@ -36,6 +38,60 @@
 				"vitest": "^0.25.3"
 			}
 		},
+		"node_modules/@auth/core": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@auth/core/-/core-0.5.0.tgz",
+			"integrity": "sha512-NZu+H1rfYPewBDelZ4nZn7Vd2i6kVSUZQAcrQtEYylbSVVpVglcAfnHDq0FsIFXN1czQk13qdmm+CbIEr/C+iA==",
+			"dependencies": {
+				"@panva/hkdf": "^1.0.4",
+				"cookie": "0.5.0",
+				"jose": "^4.11.1",
+				"oauth4webapi": "^2.0.6",
+				"preact": "10.11.3",
+				"preact-render-to-string": "5.2.3"
+			},
+			"peerDependencies": {
+				"nodemailer": "^6.8.0"
+			},
+			"peerDependenciesMeta": {
+				"nodemailer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@auth/sveltekit": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@auth/sveltekit/-/sveltekit-0.2.2.tgz",
+			"integrity": "sha512-8PL1120J22RrmsGu8VXTeUvTldSNRqvs/hhEsx9DYswdS5o4umhXsJI5JDbBS3hzpuq7i4LgVEOueW7zQgn9dg==",
+			"dependencies": {
+				"@auth/core": "0.4.0"
+			},
+			"peerDependencies": {
+				"@sveltejs/kit": "^1.0.0",
+				"svelte": "^3.54.0"
+			}
+		},
+		"node_modules/@auth/sveltekit/node_modules/@auth/core": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@auth/core/-/core-0.4.0.tgz",
+			"integrity": "sha512-wHVljvVGPmKSjlxQUYZCOL4GGe26YqhT351sA2REE43YskaqRMYh1TVjBxpXcdG8/P8bw2DsHgl+aBEV3P5+KQ==",
+			"dependencies": {
+				"@panva/hkdf": "^1.0.2",
+				"cookie": "0.5.0",
+				"jose": "^4.11.1",
+				"oauth4webapi": "^2.0.6",
+				"preact": "10.11.3",
+				"preact-render-to-string": "5.2.3"
+			},
+			"peerDependencies": {
+				"nodemailer": "^6.8.0"
+			},
+			"peerDependenciesMeta": {
+				"nodemailer": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@esbuild/android-arm": {
 			"version": "0.16.17",
 			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
@@ -43,7 +99,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -59,7 +114,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -75,7 +129,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -91,7 +144,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -107,7 +159,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -123,7 +174,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -139,7 +189,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"freebsd"
@@ -155,7 +204,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -171,7 +219,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -187,7 +234,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -203,7 +249,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -219,7 +264,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -235,7 +279,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -251,7 +294,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -267,7 +309,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -283,7 +324,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -299,7 +339,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"netbsd"
@@ -315,7 +354,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"openbsd"
@@ -331,7 +369,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"sunos"
@@ -347,7 +384,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -363,7 +399,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -379,7 +414,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -456,8 +490,7 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.17",
@@ -504,11 +537,18 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@panva/hkdf": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.0.4.tgz",
+			"integrity": "sha512-003xWiCuvePbLaPHT+CRuaV4GlyCAVm6XYSbBZDHoWZGn1mNkVKFaDbGJjjxmEFvizUwlCoM6O18FCBMMky2zQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/@polka/url": {
 			"version": "1.0.0-next.21",
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.21.tgz",
-			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
-			"dev": true
+			"integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
 		},
 		"node_modules/@skeletonlabs/skeleton": {
 			"version": "0.132.5",
@@ -535,7 +575,6 @@
 			"version": "1.8.4",
 			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.8.4.tgz",
 			"integrity": "sha512-SUNHiaFuvOxeu/3wVLbdR2ki9sqcPEQUOtxWulI+H7fa1JfSTYuA0KgjValVlKBUlyWiW9XKyTtSE+I+qQOToA==",
-			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte": "^2.0.0",
@@ -567,7 +606,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.3.tgz",
 			"integrity": "sha512-o+cguBFdwIGtRbNkYOyqTM7KvRUffxh5bfK4oJsWKG2obu+v/cbpT03tJrGl58C7tRXo/aEC0/axN5FVHBj0nA==",
-			"dev": true,
 			"dependencies": {
 				"debug": "^4.3.4",
 				"deepmerge": "^4.3.0",
@@ -588,7 +626,6 @@
 			"version": "0.29.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
 			"integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.13"
 			},
@@ -626,8 +663,7 @@
 		"node_modules/@types/cookie": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz",
-			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==",
-			"dev": true
+			"integrity": "sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
@@ -639,7 +675,7 @@
 			"version": "18.14.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
 			"integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/@types/pug": {
 			"version": "2.0.6",
@@ -1106,7 +1142,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
 			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-			"dev": true,
 			"dependencies": {
 				"streamsearch": "^1.1.0"
 			},
@@ -1258,7 +1293,6 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
 			"integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -1293,7 +1327,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -1328,7 +1361,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
 			"integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1371,8 +1403,7 @@
 		"node_modules/devalue": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.0.tgz",
-			"integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
-			"dev": true
+			"integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA=="
 		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
@@ -1426,7 +1457,6 @@
 			"version": "0.16.17",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
 			"integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
-			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
@@ -1632,8 +1662,7 @@
 		"node_modules/esm-env": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
-			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
-			"dev": true
+			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA=="
 		},
 		"node_modules/espree": {
 			"version": "9.4.1",
@@ -1849,7 +1878,6 @@
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
 			"os": [
@@ -1862,8 +1890,7 @@
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"node_modules/get-func-name": {
 			"version": "2.0.0",
@@ -1924,8 +1951,7 @@
 		"node_modules/globalyzer": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
-			"dev": true
+			"integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
 		},
 		"node_modules/globby": {
 			"version": "11.1.0",
@@ -1950,8 +1976,7 @@
 		"node_modules/globrex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-			"dev": true
+			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
@@ -1969,7 +1994,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1"
 			},
@@ -2062,7 +2086,6 @@
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
 			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
-			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
 			},
@@ -2115,6 +2138,14 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true
 		},
+		"node_modules/jose": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-4.12.0.tgz",
+			"integrity": "sha512-wW1u3cK81b+SFcHjGC8zw87yuyUweEFe0UJirrXEw1NasW00eF7sZjeG3SLBGz001ozxQ46Y9sofDvhBmWFtXQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
 		"node_modules/js-sdsl": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
@@ -2153,7 +2184,6 @@
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
 			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2238,7 +2268,6 @@
 			"version": "0.30.0",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
 			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.13"
 			},
@@ -2272,7 +2301,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
 			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-			"dev": true,
 			"bin": {
 				"mime": "cli.js"
 			},
@@ -2335,7 +2363,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
 			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2344,7 +2371,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
 			"integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -2352,14 +2378,12 @@
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
 			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -2401,6 +2425,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/oauth4webapi": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.1.0.tgz",
+			"integrity": "sha512-0YjXQA3viCby/So8rja4sBrdLMTTyzuQTzotMTT6uAgqmqanrpt8eBfLLaugUZaMZSzt3IdjJdGadr5YTC+Cww==",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/object-hash": {
@@ -2510,8 +2542,7 @@
 		"node_modules/path-parse": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-			"dev": true
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -2534,8 +2565,7 @@
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"dev": true
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -2562,7 +2592,6 @@
 			"version": "8.4.21",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
 			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2685,6 +2714,26 @@
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"dev": true
 		},
+		"node_modules/preact": {
+			"version": "10.11.3",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+			"integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
+		"node_modules/preact-render-to-string": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+			"integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+			"dependencies": {
+				"pretty-format": "^3.8.0"
+			},
+			"peerDependencies": {
+				"preact": ">=10"
+			}
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2793,6 +2842,11 @@
 				}
 			}
 		},
+		"node_modules/pretty-format": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+			"integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
+		},
 		"node_modules/punycode": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -2871,7 +2925,6 @@
 			"version": "1.22.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
 			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-			"dev": true,
 			"dependencies": {
 				"is-core-module": "^2.9.0",
 				"path-parse": "^1.0.7",
@@ -2922,7 +2975,6 @@
 			"version": "3.17.2",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.17.2.tgz",
 			"integrity": "sha512-qMNZdlQPCkWodrAZ3qnJtvCAl4vpQ8q77uEujVCCbC/6CLB7Lcmvjq7HyiOSnf4fxTT9XgsE36oLHJBH49xjqA==",
-			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
@@ -2961,7 +3013,6 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
 			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-			"dev": true,
 			"dependencies": {
 				"mri": "^1.1.0"
 			},
@@ -3011,8 +3062,7 @@
 		"node_modules/set-cookie-parser": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
-			"dev": true
+			"integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -3039,7 +3089,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.2.tgz",
 			"integrity": "sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==",
-			"dev": true,
 			"dependencies": {
 				"@polka/url": "^1.0.0-next.20",
 				"mrmime": "^1.0.0",
@@ -3086,7 +3135,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3102,7 +3150,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
 			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
 			}
@@ -3171,7 +3218,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -3183,7 +3229,6 @@
 			"version": "3.55.1",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.1.tgz",
 			"integrity": "sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==",
-			"dev": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -3304,7 +3349,6 @@
 			"version": "0.15.1",
 			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.1.tgz",
 			"integrity": "sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==",
-			"dev": true,
 			"engines": {
 				"node": "^12.20 || ^14.13.1 || >= 16"
 			},
@@ -3476,7 +3520,6 @@
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
 			"integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
-			"dev": true,
 			"dependencies": {
 				"globalyzer": "0.1.0",
 				"globrex": "^0.1.2"
@@ -3522,7 +3565,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.0.tgz",
 			"integrity": "sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -3604,7 +3646,6 @@
 			"version": "5.20.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
 			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
-			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"
 			},
@@ -3657,7 +3698,6 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
 			"integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
-			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.16.14",
 				"postcss": "^8.4.21",
@@ -3706,7 +3746,6 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.4.tgz",
 			"integrity": "sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==",
-			"dev": true,
 			"peerDependencies": {
 				"vite": "^3.0.0 || ^4.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@auth/core": "^0.5.0",
+		"@auth/sveltekit": "^0.2.2",
 		"zod": "^3.20.6"
 	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,7 +1,11 @@
+import type { Session } from '@auth/core/types';
+
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			session: Session;
+		}
 		// interface PageData {}
 		// interface Platform {}
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,26 @@
+import { SvelteKitAuth } from '@auth/sveltekit';
+import Discord from '@auth/core/providers/discord';
+import { DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET } from '$env/static/private';
+import type { Handle } from '@sveltejs/kit';
+
+if (!DISCORD_CLIENT_ID) {
+	throw new Error('Missing DISCORD_CLIENT_ID in .env');
+}
+
+if (!DISCORD_CLIENT_SECRET) {
+	throw new Error('Missing DISCORD_CLIENT_SECRET in .env');
+}
+
+export const handle = (async (...args) => {
+	return SvelteKitAuth({
+		trustHost: true,
+		providers: [
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			Discord({
+				clientId: DISCORD_CLIENT_ID,
+				clientSecret: DISCORD_CLIENT_SECRET
+			})
+		]
+	})(...args);
+}) satisfies Handle;

--- a/src/lib/Component.svelte
+++ b/src/lib/Component.svelte
@@ -1,0 +1,1 @@
+<h1>That's a basic component to showcase path aliases!</h1>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async (event) => {
+	return {
+		session: await event.locals.getSession()
+	};
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,36 @@
+<script>
+	import { signIn, signOut } from '@auth/sveltekit/client';
+	import { page } from '$app/stores';
+	import { Avatar } from '@skeletonlabs/skeleton';
+	import RandomComponent from '$lib/Component.svelte';
+</script>
+
 <div
 	class="container mx-auto flex h-full w-full flex-col items-center justify-center space-y-8 p-8"
 >
 	<h1>Project D.</h1>
 	<p>Good luck and have fun!</p>
 
-	<label class="label">
-		<span>And this is a random input that does nothing.</span>
-		<input class="input px-4 py-2" />
-	</label>
+	<RandomComponent />
+
+	<div class="card flex flex-col py-6 px-8">
+		{#if $page.data.session}
+			<div class="flex items-center justify-center">
+				{#if $page.data.session?.user?.image}
+					<Avatar src={$page.data.session?.user?.image} />
+				{/if}
+				<span class="ml-4 text-2xl font-bold">
+					{$page.data.session.user?.name ?? ''}
+				</span>
+			</div>
+			<button on:click={() => signOut()} class="btn variant-filled-primary mt-4 w-full"
+				>Sign out</button
+			>
+		{:else}
+			<span class="text-center text-2xl font-bold">You are not signed in.</span>
+			<button on:click={() => signIn('discord')} class="btn variant-filled-primary mt-4 w-full"
+				>Sign In with Discord</button
+			>
+		{/if}
+	</div>
 </div>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,10 @@ const config = {
 	],
 
 	kit: {
-		adapter: adapter()
+		adapter: adapter(),
+		alias: {
+			$lib: 'src/lib'
+		}
 	}
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,11 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"baseUrl": ".",
+		"paths": {
+			"$lib": ["src/lib"],
+			"$lib/*": ["src/lib/*"]
+		}
 	}
 }


### PR DESCRIPTION
Added basic auth using [Auth.js](https://authjs.dev/reference/sveltekit) for sveltekit.  
Added path alias setup.  

To begin working with Auth you have to create an app [here](https://discord.com/developers/applications) and pass env variables to `.env` file like so:  

```
DISCORD_CLIENT_ID=YOUR-DISCORD-CLIENT-ID
DISCORD_CLIENT_SECRET=YOUR-DISCORD-CLIENT-SECRET
AUTH_SECRET=fc3dea3e40bbd0439fd6300879264ca39107204f122b5dc57de81f91b36202fc
```

Besides, you have to add a callback in discord developer portal:  
`http://localhost:1337/auth/callback/discord`

And that's it! You should be all set up to work with auth in the app.